### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SixfabCellularIoT	KEYWORD1	
+SixfabCellularIoT	KEYWORD1
 DEBUG	KEYWORD1
 GNSS	KEYWORD1
 compose	KEYWORD1
@@ -56,9 +56,9 @@ activateContext	KEYWORD2
 deactivateContext	KEYWORD2
 connectToServerTCP	KEYWORD2
 sendDataTCP	KEYWORD2
-sendDataSixfabConnect KEYWORD2
-sendDataIFTTT KEYWORD2
-sendDataThingspeak KEYWORD2
+sendDataSixfabConnect	KEYWORD2
+sendDataIFTTT	KEYWORD2
+sendDataThingspeak	KEYWORD2
 startUDPService	KEYWORD2
 sendDataUDP	KEYWORD2
 closeConnection	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords